### PR TITLE
Fix scanner just not working on ALL systems

### DIFF
--- a/src/join/Scanner.tsx
+++ b/src/join/Scanner.tsx
@@ -41,6 +41,13 @@ const defaultLocatorSettings: DefaultLocatorSettings = {
   halfSample: true,
 };
 
+const debugConfig = {
+  drawBoundingBox: true,
+  showFrequency: true,
+  drawScanline: true,
+  showPattern: true,
+};
+
 const defaultDecoders = ["code_39_reader", "code_39_vin_reader"];
 
 const Scanner = ({
@@ -62,6 +69,7 @@ const Scanner = ({
         result === undefined ||
         result.codeResult === undefined
       ) {
+        console.log("Not detected");
         return;
       }
 
@@ -124,10 +132,11 @@ const Scanner = ({
             ...(!cameraId && { facingMode }),
           },
           target: scannerRef.current,
+          singleChannel: true,
         },
         locator,
         numOfWorkers,
-        decoder: { readers: decoders, multiple: true },
+        decoder: { readers: decoders, multiple: true, debug: debugConfig },
         locate,
       },
       (err) => {

--- a/src/join/Scanner.tsx
+++ b/src/join/Scanner.tsx
@@ -63,11 +63,11 @@ const Scanner = ({
   locate = true,
 }: ScannerProps) => {
   const errorCheck = useCallback(
-    (result: QuaggaJSResultObject) => {
+    (results: QuaggaJSResultObject[]) => {
+      const result = results[0]
+
       if (
-        !onDetected ||
-        result === undefined ||
-        result.codeResult === undefined
+        !onDetected
       ) {
         console.log("Not detected");
         return;
@@ -76,8 +76,14 @@ const Scanner = ({
       const err = getMedianOfCodeErrors(result.codeResult.decodedCodes);
       // if Quagga is at least 75% certain that it read correctly, then accept the code.
       if (err < 0.25) {
-        onDetected(result.codeResult.code);
+      
+      onDetected(result.codeResult.code);
       }
+      
+
+      // if (result.codeResult && result.codeResult.code !== undefined) {
+      //   onDetected(result.codeResult.code);
+      //      }
     },
     [onDetected]
   );
@@ -154,8 +160,10 @@ const Scanner = ({
         }
       }
     );
+    // @ts-ignore
     Quagga.onDetected(errorCheck);
     return () => {
+      // @ts-ignore
       Quagga.offDetected(errorCheck);
       Quagga.offProcessed(handleProcessed);
       Quagga.stop();

--- a/src/join/Scanner.tsx
+++ b/src/join/Scanner.tsx
@@ -42,10 +42,10 @@ const defaultLocatorSettings: DefaultLocatorSettings = {
 };
 
 const debugConfig = {
-  drawBoundingBox: true,
-  showFrequency: true,
-  drawScanline: true,
-  showPattern: true,
+  drawBoundingBox: false,
+  showFrequency: false,
+  drawScanline: false,
+  showPattern: false,
 };
 
 const defaultDecoders = ["code_39_reader", "code_39_vin_reader"];


### PR DESCRIPTION
For some reason Quagga was returning an array of results instead of a single object. Totaly not what the typedefs say but ¯\\_(ツ)_/¯